### PR TITLE
Add missing array index set

### DIFF
--- a/src/com/hms_networks/americas/sc/taginfo/TagInfoManager.java
+++ b/src/com/hms_networks/americas/sc/taginfo/TagInfoManager.java
@@ -80,6 +80,7 @@ public class TagInfoManager {
 
         // Reached end of line. Reset byte received array
         receivedBytes = new byte[maxBytesPerLine];
+        receivedBytesInsertIndex = 0;
       }
 
       /*


### PR DESCRIPTION
Add a missing reset for the byte array insertion index when the byte array is reset.

This prevented the internal tag info list from being populated in some scenarios, and broke other functionality that was dependent on that tag info list